### PR TITLE
Fix UnboundLocalError by ensuring 'out' variable is always initialized

### DIFF
--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -667,6 +667,9 @@ def load_array(fpath, variable_name=None, idx=None, random_wait=0, cache_dir=Non
         stressing system / network by too many simultaneous read requests.
     kwargs : passed to load_mp4 (and potentially other future functions.)
     """
+
+    out = None  # Initialize 'out' to ensure it's always defined
+
     path, fname = os.path.split(str(fpath))
     bucket, full_path = cloud_bucket_check(path)
     # Check for cache dir for quicker loading


### PR DESCRIPTION
The issue was in the load_array function, line 651, it would raise an UnboundLocalError since the returned variable 'out' is defined in if statement,  I Initialized 'out' to 'None' at the start of the function to ensure it's always defined (line 671).