### PR TITLE
Handle hdf keys

### DIFF
--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -521,7 +521,7 @@ def list_array_keys(fpath):
         npz = np.load(fpath, mmap_mode='r')
         return npz.files
     else:
-        raise ValueError("Untenable file type")
+        raise ValueError(f"Loading of detected type {ext} not implemented.")
 
 def list_array_shapes(fpath, variable_name=None, cloudi=None):
     """"""
@@ -564,7 +564,7 @@ def list_array_shapes(fpath, variable_name=None, cloudi=None):
                 # nf = np.round(meta['duration'] * meta['fps']).astype(np.int)
                 return [nf, y, x, 3]
         else:
-            raise ValueError('Only usable for hdf, mp4, and npy files for now.')
+            raise ValueError(f"Loading of detected type {ext} not implemented.")
 
 def _list_npz_shapes(fpath):
     """
@@ -725,7 +725,7 @@ def load_array(fpath, variable_name=None, idx=None, random_wait=0, cache_dir=Non
         elif ext in ('.npz',):
             out = _load_npz_array(fpath, variable_name=variable_name, idx=idx)
         else:
-            raise ValueError(f"Loading detected type {ext} not implemented.")
+            raise ValueError(f"Loading of detected type {ext} not implemented.")
 
     else:
         cloudi = get_interface(bucket_name=bucket, verbose=False, config=botoconfig)

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -754,15 +754,16 @@ def _load_mat_array(fpath, variable_name=None, idx=None):
 
     TODO: idx
     """
-    if variable_name is None:
-        # TODO: soften this? If only one variable exists in file, load that?
-        raise ValueError("variable_name must be specified for hdf files")    
     try:
+        if variable_name is None:
+            keys = file_array_keys(fpath)
+            if len(keys)==1:
+                    logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
+                    variable_name = keys[0]
+            else:
+                raise ValueError(f"Variable_name must be specified for mat files with multiple keys. Available keys: {keys}")
         # Maybe it's a just a .mat file
-        d = loadmat(fpath)
-        if not variable_name in d:
-            raise ValueError('array "%s" not found in %s!'%(variable_name, fpath))
-        return d[variable_name]
+        return loadmat(fpath, variable_names=[variable_name])
     except: # NotImplementedError:
         # Note: Better to catch a specific error here, but it seems the error for loadmat has changed.
         # Now catching a generic error instead.

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -731,7 +731,7 @@ def _load_hdf_array(fpath, variable_name=None, idx=None):
                     warnings.warn(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
                     variable_name = keys[0]
                 else:
-                    raise ValueError("Variable_name must be specified for hdf files with multiple keys.")
+                    raise ValueError(f"Variable_name must be specified for hdf files with multiple keys. Available keys: {keys}")
             if idx is None:
                 out = hf[variable_name][:]
             else:

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -497,7 +497,7 @@ def fexists(fpath, variable_name=None):
             file_exists = cloudi.exists_object(array_name)
         return file_exists
 
-def file_array_keys(fpath):
+def list_file_keys(fpath):
     """Get keys for variable stored in a file
 
     Does NOT support cloud arrays yet.
@@ -519,7 +519,7 @@ def file_array_keys(fpath):
     else:
         raise ValueError("Untenable file type")
 
-def var_size(fpath, variable_name=None, cloudi=None):
+def list_file_sizes(fpath, variable_name=None, cloudi=None):
     """"""
     path, fname = os.path.split(fpath)
     bucket, path = cloud_bucket_check(path)

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -841,9 +841,9 @@ def save_arrays(fpath, fname=None, meta=None, acl='public-read', compression=Tru
             _save_arrays_hdf(fpath, meta=meta, compression=compression, **named_vars)
         elif ext in ('.npz',):
             if compression is True:
-                np.savez(fpath, **named_vars)
-            elif compression is False:
                 np.savez_compressed(fpath, **named_vars)
+            elif compression is False:
+                np.savez(fpath, **named_vars)
         elif ext in ('.mat',):
             savemat(fpath, named_vars, do_compression=compression)
         else:

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -737,7 +737,7 @@ def _load_hdf_array(fpath, variable_name=None, idx=None):
             keys = list(hf.keys())
             if variable_name is None:
                 if len(keys)==1:
-                    logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
+                    logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.')
                     variable_name = keys[0]
                 else:
                     raise ValueError(f"Variable_name must be specified for hdf files with multiple keys. Available keys: {keys}")
@@ -754,20 +754,15 @@ def _load_mat_array(fpath, variable_name=None, idx=None):
 
     TODO: idx
     """
-    try:
-        if variable_name is None:
-            keys = file_array_keys(fpath)
-            if len(keys)==1:
-                    logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
-                    variable_name = keys[0]
-            else:
-                raise ValueError(f"Variable_name must be specified for mat files with multiple keys. Available keys: {keys}")
-        # Maybe it's a just a .mat file
-        return loadmat(fpath, variable_names=[variable_name])
-    except: # NotImplementedError:
-        # Note: Better to catch a specific error here, but it seems the error for loadmat has changed.
-        # Now catching a generic error instead.
-        return _load_hdf_array(fpath, variable_name=variable_name, idx=idx)
+    if variable_name is None:
+        keys = file_array_keys(fpath)
+        if len(keys)==1:
+                logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.')
+                variable_name = keys[0]
+        else:
+            raise ValueError(f"Variable_name must be specified for mat files with multiple keys. Available keys: {keys}")
+    # Maybe it's a just a .mat file
+    return loadmat(fpath, variable_names=[variable_name])
 
 
 def save_arrays(fpath, fname=None, meta=None, acl='public-read', compression=True, **named_vars):

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -696,7 +696,7 @@ def load_array(fpath, variable_name=None, idx=None, random_wait=0, cache_dir=Non
             # Assume loading whole thing is not going to kill memory if
             # we're loading an npy file; bigger arrays should be stored
             # as HDFs or some format that allows partial load
-            out = np.load(fpath)
+            out = np.load(fpath, mmap_mode='r')
             if idx is not None:
                 out = out[idx[0]:idx[1]]
 
@@ -734,7 +734,7 @@ def _load_hdf_array(fpath, variable_name=None, idx=None):
                 else:
                     raise ValueError(f"Variable_name must be specified for hdf files with multiple keys. Available keys: {keys}")
             if idx is None:
-                out = hf[variable_name][:]
+                out = hf[variable_name]
             else:
                 st, fin = idx
                 out = hf[variable_name][st:fin]

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -723,9 +723,7 @@ def load_array(fpath, variable_name=None, idx=None, random_wait=0, cache_dir=Non
             if idx is not None:
                 out = out[idx[0]:idx[1]]
         elif ext in ('.npz',):
-            out = np.load(fpath, mmap_mode='r')[variable_name]
-            if idx is not None:
-                out = out[idx[0]:idx[1]]
+            out = _load_npz_array(fpath, variable_name=variable_name, idx=idx)
         else:
             raise ValueError(f"Loading detected type {ext} not implemented.")
 
@@ -789,6 +787,20 @@ def _load_mat_array(fpath, variable_name=None, idx=None):
         out = _load_hdf_array(fpath, variable_name=variable_name, idx=idx)
     return out
 
+def _load_npz_array(fpath, variable_name=None, idx=None):
+    """Load array from numpy .npz file
+    """
+    if variable_name is None:
+        keys = list_array_keys(fpath)
+        if len(keys)==1:
+                logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.')
+                variable_name = keys[0]
+        else:
+            raise ValueError(f"Variable_name must be specified for mat files with multiple keys. Available keys: {keys}")
+    out = np.load(fpath, mmap_mode='r')[variable_name]
+    if idx is not None:
+        out = out[idx[0]:idx[1]]
+    return out
 
 def save_arrays(fpath, fname=None, meta=None, acl='public-read', compression=True, **named_vars):
     """"Layer of abstraction for saving files.

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -721,15 +721,17 @@ def _load_hdf_array(fpath, variable_name=None, idx=None):
     idx : tuple
         (start_index, end_index) to load - only works on FIRST DIMENSION for now.
     """
-    if variable_name is None:
-        # TODO: soften this? If only one variable exists in file, load that?
-        raise ValueError("variable_name must be specified for hdf files")
     with warnings.catch_warnings():
         # Ignore bullshit h5py/tables warning 
-        warnings.simplefilter("ignore")
+        # warnings.simplefilter("ignore")
         with h5py.File(fpath, 'r') as hf:
-            #if not variable_name in hf: # This raises very annoying warnings, thus it's off for now
-            #    raise ValueError('array "%s" not found in %s!'%(variable_name, fpath))
+            keys = list(hf.keys())
+            if variable_name is None:
+                if len(keys)==1:
+                    warnings.warn(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
+                    variable_name = keys[0]
+                else:
+                    raise ValueError("Variable_name must be specified for hdf files with multiple keys.")
             if idx is None:
                 out = hf[variable_name][:]
             else:

--- a/file_io/utils.py
+++ b/file_io/utils.py
@@ -20,6 +20,7 @@ import numpy as np
 from PIL import Image
 from scipy.io import loadmat
 from matplotlib.pyplot import imread  as _imread
+import logging
 #from . import options
 
 # Soft imports for obscure or heavy modules
@@ -728,7 +729,7 @@ def _load_hdf_array(fpath, variable_name=None, idx=None):
             keys = list(hf.keys())
             if variable_name is None:
                 if len(keys)==1:
-                    warnings.warn(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
+                    logging.warning(f'No variable_name specified, but file has only one key ({keys[0]}), so this key will be used.', stacklevel=2)
                     variable_name = keys[0]
                 else:
                     raise ValueError(f"Variable_name must be specified for hdf files with multiple keys. Available keys: {keys}")


### PR DESCRIPTION
Adds better handling of HDF file keys when the key to load is not specified.

In cases where the HDF has only one key, the corresponding array is loaded.

In cases where the HDF has multiple keys, these keys are listed in the error message (so you don't have to figure these out some other way).